### PR TITLE
Add Python 3.3 environment to tox-travis

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,5 +3,6 @@ wheel
 tox
 coverage
 Sphinx
-pytest
+pytest >= 3.0; python_version != '3.3'
+pytest <  3.3; python_version == '3.3'
 pytest-runner

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ python =
     3.6: py36
     3.5: py35
     3.4: py34
+    3.3: py33
     2.7: py27
 
 [testenv:flake8]


### PR DESCRIPTION
This is the reason that the Python 3.3 build is currently failing - it's not being run.