### PR TITLE
Fix documentation and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,6 @@ variants
         :target: https://variants.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://pyup.io/repos/github/python-variants/variants/shield.svg
-     :target: https://pyup.io/repos/github/python-variants/variants/
-     :alt: Updates
-
 ``variants`` is a library that provides syntactic sugar for creating alternate forms of functions and other callables, in the same way that alternate constructors are class methods that provide alternate forms of the constructor function.
 
 To create a function with variants, simply decorate the primary form with ``@variants.primary``, which then adds the ``.variant`` decorator to the original function, which can be used to register new variants. Here is a simple example of a function that prints text, with variants that specify the source of the text to print:
@@ -71,13 +67,4 @@ Requirements
 ------------
 
 This is a library for Python, with support for versions 2.7 and 3.4+.
-
-
-Credits
----------
-
-This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.
-
-.. _Cookiecutter: https://github.com/audreyr/cookiecutter
-.. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ project_root = os.path.dirname(cwd)
 # Insert the project root dir as the first element in the PYTHONPATH.
 # This lets us ensure that the source package is imported, and that its
 # version is used.
-sys.path.insert(0, project_root)
+sys.path.insert(0, os.path.join(project_root, 'src'))
 
 import variants
 
@@ -142,7 +142,7 @@ html_theme = 'default'
 # here, relative to this directory. They are copied after the builtin
 # static files, so a file named "default.css" will overwrite the builtin
 # "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,10 @@
 Welcome to variants's documentation!
 ======================================
 
+.. include:: ../README.rst
+
+Documentation
+=============
 Contents:
 
 .. toctree::
@@ -9,7 +13,6 @@ Contents:
    readme
    installation
    usage
-   modules
    contributing
    authors
    history

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, flake8
+envlist = py27, py33, py34, py35, py36, flake8, docs
+skip_missing_interpreters = true
 
 [travis]
 python =
@@ -24,8 +25,9 @@ commands =
     pip install -U .
     pytest --basetemp={envtmpdir}
 
-
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs, check that URIs are valid
+basepython = python3.6
+deps = {[testenv]deps}
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" {posargs:-W --color -bhtml}
+           sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" {posargs:-W --color -blinkcheck}


### PR DESCRIPTION
1. Drops `pyup`, because that organization requires write access to repos, and seems to mostly just spam you to pin dependencies - no thanks.
2. Should fix readthedocs build.
3. Adds a documentation build checker (which mainly fails because the readthedocs build is broken).