### PR TITLE
Add support for singledispatch (does not work with methods)

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,7 @@ wheel
 tox
 coverage
 Sphinx
+singledispatch; python_version <= '3.3'
 pytest >= 3.0; python_version != '3.3'
 pytest <  3.3; python_version == '3.3'
 pytest-runner

--- a/src/variants/_variants.py
+++ b/src/variants/_variants.py
@@ -38,6 +38,9 @@ class VariantFunction(object):
     def __call__(self, *args, **kwargs):
         return self.__main_form__(*args, **kwargs)
 
+    def __getattr__(self, key):
+        return getattr(self.__main_form__, key)
+
     def _add_variant(self, var_name, vfunc):
         self._variants.add(var_name)
         setattr(self, var_name, vfunc)

--- a/tests/test_single_dispatch.py
+++ b/tests/test_single_dispatch.py
@@ -1,0 +1,63 @@
+from __future__ import division
+
+import pytest
+
+try:
+    from functools import singledispatch
+except ImportError:
+    from singledispatch import singledispatch
+
+import variants
+
+
+###
+# Example implementation - single dispatched function
+@variants.primary
+@singledispatch
+def add_one(arg):
+    return arg + 1
+
+
+@add_one.variant('from_list')
+@add_one.register(list)
+def add_one(arg):
+    return arg + [1]
+
+
+@add_one.variant('from_tuple')
+@add_one.register(tuple)
+def add_one(arg):
+    return arg + (1,)
+
+
+### Tests
+def test_single_dispatch_int():
+    assert add_one(1) == 2
+
+
+def test_single_dispatch_list():
+    assert add_one([2]) == [2, 1]
+
+
+def test_single_dispatch_tuple():
+    assert add_one((2,)) == (2, 1)
+
+
+def test_dispatch_list_variant_succeeds():
+    assert add_one.from_list([4]) == [4, 1]
+
+
+@pytest.mark.parametrize('arg', [3, (2,)])
+def test_dispatch_list_variant_fails(arg):
+    with pytest.raises(TypeError):
+        add_one.from_list(arg)
+
+
+def test_dispatch_tuple_variant_succeeds():
+    assert add_one.from_tuple((2,)) == (2, 1)
+
+
+@pytest.mark.parametrize('arg', [3, [2]])
+def test_dispatch_tuple_variant_fails(arg):
+    with pytest.raises(TypeError):
+        add_one.from_tuple(arg)


### PR DESCRIPTION
Fixes #2. We need to be the *outer* decorator in this case, but at least that's consistent.