### PR TITLE
Fix changelog documentation after HISTORY move

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,4 @@
+Changelog
+=========
+
+.. include:: ../NEWS.rst

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,1 +1,0 @@
-.. include:: ../HISTORY.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Contents:
    usage
    contributing
    authors
-   history
+   changelog
 
 Indices and tables
 ==================


### PR DESCRIPTION
The documentation build was failing because `HISTORY.rst` was moved to `NEWS.rst`. This fixes that and changes the `HISTORY` name in the documentation to `CHANGELOG` (which I like better - maybe change `NEWS.rst` as well at some point?