### PR TITLE
Add inspect functions to module

### DIFF
--- a/src/variants/inspect.py
+++ b/src/variants/inspect.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Provides inspection tools for extracting metadata from function groups.
+"""
+from ._variants import VariantFunction, VariantMethod
+
+if False:   # pragma: nocover
+    from typing import Any      # NOQA
+
+
+def is_primary(f):
+    # type: (Any) -> bool
+    """
+    Detect if a function is a primary function in a variant group
+    """
+    return isinstance(f, (VariantFunction, VariantMethod))
+
+
+def is_primary_method(f):
+    # type: (Any) -> bool
+    """
+    Detect if a function is a primary method in a variant group
+    """
+    return isinstance(f, VariantMethod)
+

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+from variants import primary
+from variants import inspect as vinsp
+
+import pytest
+
+###
+# Setup functions
+@primary
+def prim_func():
+    """Example primary function"""
+
+
+@prim_func.variant('alt')
+def prim_func():
+    """Example alternate function"""
+
+
+@prim_func.variant('prim_group')
+@primary
+def prim_func():
+    """Nested variant functions"""
+
+
+@prim_func.prim_group.variant('alt2')
+def _():
+    """Nested alternate function"""
+
+
+def rfunc():
+    """Arbitrary function"""
+
+
+class SomeClass(object):
+    @primary
+    def prim_method(self):
+        """Example of a primary method"""
+
+    @prim_method.variant('alt')
+    def prim_method(self):
+        """Example of a method alternate"""
+
+
+some_instance = SomeClass()
+
+
+###
+# Tests
+@pytest.mark.parametrize('f,exp', [
+    (prim_func, True),
+    (rfunc, False),
+    (prim_func.alt, False),
+    (prim_func.prim_group, True),
+    (prim_func.prim_group.alt2, False),
+    (SomeClass.prim_method, True),
+    (some_instance.prim_method, True),
+    (SomeClass.prim_method.alt, False),
+    (some_instance.prim_method.alt, False),
+])
+def test_is_primary(f, exp):
+    assert vinsp.is_primary(f) == exp

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -60,3 +60,18 @@ some_instance = SomeClass()
 ])
 def test_is_primary(f, exp):
     assert vinsp.is_primary(f) == exp
+
+
+@pytest.mark.parametrize('f,exp', [
+    (SomeClass.prim_method, False),
+    (some_instance.prim_method, True),
+    (SomeClass.prim_method.alt, False),
+    (some_instance.prim_method.alt, False),
+    (prim_func, False),
+    (rfunc, False),
+    (prim_func.alt, False),
+    (prim_func.prim_group, False),
+    (prim_func.prim_group.alt2, False),
+])
+def test_is_primary_method(f, exp):
+    assert vinsp.is_primary_method(f) == exp


### PR DESCRIPTION
These are there to provide a public API that will provide some information about `variants` functions.

This is a required change before I can implement a sphinx extension (at least one that uses only the public interface).