### PR TITLE
Update towncrier version title config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,6 @@
     package = "variants"
     package_dir = "src/variants"
     filename = "NEWS.rst"
+    title_format = "Version {version} ({project_date})"
+    issue_format = "GH #{issue}"
     directory = "changelog.d"


### PR DESCRIPTION
I prefer "Version x" to "Variants x".

This also explicitly mentions that issue numbers are github issues.