### PR TITLE
Fix travis for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ matrix:
       env: TOXENV=docs
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+install:
+  - pip install -U tox-travis
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
 
 # command to run tests, e.g. python setup.py test
 script: tox


### PR DESCRIPTION
This is a bug in how virtualenv released their first version that doesn't support Python 3.3 that we now have to work around.